### PR TITLE
use mariadb container

### DIFF
--- a/metal-provisioner/02-ironic.yaml
+++ b/metal-provisioner/02-ironic.yaml
@@ -60,7 +60,7 @@ spec:
             - configMapRef:
                 name: ironic-bmo-configmap
         - name: mariadb
-          image: quay.io/metal3-io/ironic
+          image: quay.io/metal3-io/mariadb
           imagePullPolicy: Always
           command:
             - /bin/runmariadb


### PR DESCRIPTION
Per metal3-io/ironic-image#339: using the proper image, due to container execution error.

Signed-off-by: Brandon B. Jozsa <bjozsa@jinkit.com>